### PR TITLE
Fix TypeScript errors in navigation components

### DIFF
--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -67,7 +67,7 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                                     <div className="flex h-full flex-col justify-between text-sm">
                                         <div className="flex flex-col space-y-4">
                                             {mainNavItems.map((item) => (
-                                                <Link key={item.title} href={item.href} className="flex items-center space-x-2 font-medium">
+                                                <Link key={item.title} href={item.href || '#'} className="flex items-center space-x-2 font-medium">
                                                     {item.icon && <Icon iconNode={item.icon} className="h-5 w-5" />}
                                                     <span>{item.title}</span>
                                                 </Link>
@@ -105,7 +105,7 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                                 {mainNavItems.map((item, index) => (
                                     <NavigationMenuItem key={index} className="relative flex h-full items-center">
                                         <Link
-                                            href={item.href}
+                                            href={item.href || '#'}
                                             className={cn(
                                                 navigationMenuTriggerStyle(),
                                                 page.url === item.href && activeItemStyles,

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -1,5 +1,6 @@
 // import { LucideIcon } from 'lucide-react';
 import type { Config } from 'ziggy-js';
+import { LucideIcon } from 'lucide-react';
 
 export interface Auth {
     user: User;
@@ -18,7 +19,8 @@ export interface NavGroup {
 export interface NavItem {
     title: string;
     href?: string;
-    type: string;
+    type?: string;
+    icon?: LucideIcon;
     items?: NavItem[];
     isActive?: boolean;
 }


### PR DESCRIPTION
## Changes
- Updated the NavItem interface in types/index.d.ts:
  - Added icon: LucideIcon property
  - Made type property optional
  - Added proper import for LucideIcon
- Added fallback values for optional href properties in `app-header.tsx`:
  - Used `href={item.href || '#'}` pattern to ensure `href` is always a string
  - Fixes "Type 'string | undefined' is not assignable to type 'string'" errors
## Why
These changes resolve TypeScript errors that occurred because the component was using properties that weren't properly defined in the type definition. The fallbacks for optional properties ensure type safety without changing component behavior.